### PR TITLE
fix: skip nonce check if the parameter is missing in the request

### DIFF
--- a/verifier.go
+++ b/verifier.go
@@ -77,9 +77,16 @@ func WithMaxAge(d time.Duration) VerifierOption {
 }
 
 func WithNonceChecker(checker NonceChecker) VerifierOption {
-	return func(v *verifier, _ *expectations, _ bool) error {
+	forceCheckOnCustomChecker := true
+
+	return func(v *verifier, ext *expectations, _ bool) error {
 		if checker != nil {
 			v.nonceChecker = checker
+			if ext.reqNonceCheck == nil {
+				// When we're passing a custom NonceChecker, we turn on the mandatory nonce check if it wasn't
+				// previously set using WithRequiredNonce().
+				ext.reqNonceCheck = &forceCheckOnCustomChecker
+			}
 		}
 
 		return nil
@@ -204,6 +211,7 @@ func NewVerifier(resolver KeyResolver, opts ...VerifierOption) (Verifier, error)
 	}
 
 	trueValue := true
+	falseValue := true
 
 	ver := &verifier{
 		keyResolver:     resolver,
@@ -215,7 +223,7 @@ func NewVerifier(resolver KeyResolver, opts ...VerifierOption) (Verifier, error)
 		maxAge:        30 * time.Second, //nolint:mnd
 		reqExpiresTS:  &trueValue,
 		reqCreatedTS:  &trueValue,
-		reqNonceCheck: &trueValue,
+		reqNonceCheck: &falseValue,
 	}
 
 	for _, opt := range opts {

--- a/verifier.go
+++ b/verifier.go
@@ -86,6 +86,16 @@ func WithNonceChecker(checker NonceChecker) VerifierOption {
 	}
 }
 
+// WithRequiredNonceCheck specifies if at signature verification,
+// we treat a missing "nonce" parameter as an error.
+func WithRequiredNonceCheck(flag bool) VerifierOption {
+	return func(v *verifier, exp *expectations, _ bool) error {
+		exp.reqNonceCheck = &flag
+
+		return nil
+	}
+}
+
 func WithRequiredTag(tag string, opts ...VerifierOption) VerifierOption {
 	return func(ver *verifier, _ *expectations, f bool) error {
 		if f {
@@ -202,9 +212,10 @@ func NewVerifier(resolver KeyResolver, opts ...VerifierOption) (Verifier, error)
 	}
 
 	global := &expectations{
-		maxAge:       30 * time.Second, //nolint:mnd
-		reqExpiresTS: &trueValue,
-		reqCreatedTS: &trueValue,
+		maxAge:        30 * time.Second, //nolint:mnd
+		reqExpiresTS:  &trueValue,
+		reqCreatedTS:  &trueValue,
+		reqNonceCheck: &trueValue,
 	}
 
 	for _, opt := range opts {
@@ -248,6 +259,10 @@ func NewVerifier(resolver KeyResolver, opts ...VerifierOption) (Verifier, error)
 			exp.reqCreatedTS = global.reqCreatedTS
 		}
 
+		if exp.reqNonceCheck == nil {
+			exp.reqNonceCheck = global.reqNonceCheck
+		}
+
 		if global.asb != nil && exp.asb == nil {
 			// create a copy
 			tmp := *global.asb
@@ -270,12 +285,13 @@ func NewVerifier(resolver KeyResolver, opts ...VerifierOption) (Verifier, error)
 }
 
 type expectations struct {
-	tolerance    time.Duration
-	maxAge       time.Duration
-	identifiers  []*componentIdentifier
-	asb          *AcceptSignatureBuilder
-	reqCreatedTS *bool
-	reqExpiresTS *bool
+	tolerance     time.Duration
+	maxAge        time.Duration
+	identifiers   []*componentIdentifier
+	asb           *AcceptSignatureBuilder
+	reqCreatedTS  *bool
+	reqExpiresTS  *bool
+	reqNonceCheck *bool
 }
 
 //nolint:cyclop
@@ -299,6 +315,8 @@ func (e *expectations) assert(
 		if err := nc.CheckNonce(msg.Context, nonce); err != nil {
 			return fmt.Errorf("%w: nonce validation failed: %w", ErrParameter, err)
 		}
+	} else if *e.reqNonceCheck {
+		return fmt.Errorf("%w: expected nonce parameter not present", ErrParameter)
 	}
 
 	if len(params.alg) != 0 && params.alg != keyAlg {
@@ -310,7 +328,7 @@ func (e *expectations) assert(
 
 	if params.expires.Equal(time.Time{}) {
 		if *e.reqExpiresTS {
-			return fmt.Errorf("%w: expected expires parameter not preset", ErrMissingParameter)
+			return fmt.Errorf("%w: expected expires parameter not present", ErrMissingParameter)
 		}
 	} else if now.After(params.expires.Add(e.tolerance)) {
 		return fmt.Errorf("%w: signature expired", ErrValidity)
@@ -318,7 +336,7 @@ func (e *expectations) assert(
 
 	if params.created.Equal(time.Time{}) {
 		if *e.reqCreatedTS {
-			return fmt.Errorf("%w: expected created parameter not preset", ErrMissingParameter)
+			return fmt.Errorf("%w: expected created parameter not present", ErrMissingParameter)
 		}
 	} else {
 		if now.Before(params.created.Add(-1 * e.tolerance)) {

--- a/verifier.go
+++ b/verifier.go
@@ -295,10 +295,10 @@ func (e *expectations) assert(
 	nonceValue, noncePresent := params.Params.Get(string(Nonce))
 	if noncePresent {
 		nonce = nonceValue.(string) //nolint: forcetypeassert
-	}
 
-	if err := nc.CheckNonce(msg.Context, nonce); err != nil {
-		return fmt.Errorf("%w: nonce validation failed: %w", ErrParameter, err)
+		if err := nc.CheckNonce(msg.Context, nonce); err != nil {
+			return fmt.Errorf("%w: nonce validation failed: %w", ErrParameter, err)
+		}
 	}
 
 	if len(params.alg) != 0 && params.alg != keyAlg {

--- a/verifier_test.go
+++ b/verifier_test.go
@@ -93,7 +93,7 @@ func TestExpectationsAssertParameters(t *testing.T) {
 					return params
 				}(),
 			},
-			exp: expectations{reqExpiresTS: &falseVal, reqCreatedTS: &falseVal},
+			exp: expectations{reqExpiresTS: &falseVal, reqCreatedTS: &falseVal, reqNonceCheck: &trueVal},
 			configure: func(t *testing.T, nc *NonceCheckerMock) {
 				t.Helper()
 
@@ -117,6 +117,7 @@ func TestExpectationsAssertParameters(t *testing.T) {
 					return params
 				}(),
 			},
+			exp:    expectations{reqNonceCheck: &falseVal},
 			expAlg: EcdsaP256Sha256,
 			configure: func(t *testing.T, nc *NonceCheckerMock) {
 				t.Helper()
@@ -139,7 +140,7 @@ func TestExpectationsAssertParameters(t *testing.T) {
 					return params
 				}(),
 			},
-			exp: expectations{reqExpiresTS: &falseVal, reqCreatedTS: &falseVal},
+			exp: expectations{reqExpiresTS: &falseVal, reqCreatedTS: &falseVal, reqNonceCheck: &falseVal},
 			configure: func(t *testing.T, nc *NonceCheckerMock) {
 				t.Helper()
 			},
@@ -162,9 +163,10 @@ func TestExpectationsAssertParameters(t *testing.T) {
 				}(),
 			},
 			exp: expectations{
-				tolerance:    3 * time.Second,
-				reqCreatedTS: &falseVal,
-				reqExpiresTS: &falseVal,
+				tolerance:     3 * time.Second,
+				reqCreatedTS:  &falseVal,
+				reqExpiresTS:  &falseVal,
+				reqNonceCheck: &falseVal,
 			},
 			configure: func(t *testing.T, nc *NonceCheckerMock) {
 				t.Helper()
@@ -186,9 +188,10 @@ func TestExpectationsAssertParameters(t *testing.T) {
 				}(),
 			},
 			exp: expectations{
-				tolerance:    2 * time.Second,
-				reqCreatedTS: &falseVal,
-				reqExpiresTS: &falseVal,
+				tolerance:     2 * time.Second,
+				reqCreatedTS:  &falseVal,
+				reqExpiresTS:  &falseVal,
+				reqNonceCheck: &falseVal,
 			},
 			configure: func(t *testing.T, nc *NonceCheckerMock) {
 				t.Helper()
@@ -209,7 +212,7 @@ func TestExpectationsAssertParameters(t *testing.T) {
 					return params
 				}(),
 			},
-			exp: expectations{reqCreatedTS: &falseVal, reqExpiresTS: &falseVal},
+			exp: expectations{reqCreatedTS: &falseVal, reqExpiresTS: &falseVal, reqNonceCheck: &falseVal},
 			configure: func(t *testing.T, nc *NonceCheckerMock) {
 				t.Helper()
 			},
@@ -232,9 +235,10 @@ func TestExpectationsAssertParameters(t *testing.T) {
 				}(),
 			},
 			exp: expectations{
-				tolerance:    3 * time.Second,
-				reqCreatedTS: &falseVal,
-				reqExpiresTS: &falseVal,
+				tolerance:     3 * time.Second,
+				reqCreatedTS:  &falseVal,
+				reqExpiresTS:  &falseVal,
+				reqNonceCheck: &falseVal,
 			},
 			configure: func(t *testing.T, nc *NonceCheckerMock) {
 				t.Helper()
@@ -256,9 +260,10 @@ func TestExpectationsAssertParameters(t *testing.T) {
 				}(),
 			},
 			exp: expectations{
-				maxAge:       30 * time.Second,
-				reqCreatedTS: &falseVal,
-				reqExpiresTS: &falseVal,
+				maxAge:        30 * time.Second,
+				reqCreatedTS:  &falseVal,
+				reqExpiresTS:  &falseVal,
+				reqNonceCheck: &falseVal,
 			},
 			configure: func(t *testing.T, nc *NonceCheckerMock) {
 				t.Helper()
@@ -279,7 +284,7 @@ func TestExpectationsAssertParameters(t *testing.T) {
 					return params
 				}(),
 			},
-			exp: expectations{reqCreatedTS: &falseVal, reqExpiresTS: &falseVal},
+			exp: expectations{reqCreatedTS: &falseVal, reqExpiresTS: &falseVal, reqNonceCheck: &falseVal},
 			configure: func(t *testing.T, nc *NonceCheckerMock) {
 				t.Helper()
 			},
@@ -298,7 +303,7 @@ func TestExpectationsAssertParameters(t *testing.T) {
 				ids, err := toComponentIdentifiers([]string{"@method;req", "@authority"})
 				require.NoError(t, err)
 
-				return expectations{identifiers: ids, reqCreatedTS: &falseVal, reqExpiresTS: &falseVal}
+				return expectations{identifiers: ids, reqCreatedTS: &falseVal, reqExpiresTS: &falseVal, reqNonceCheck: &falseVal}
 			}(),
 			configure: func(t *testing.T, nc *NonceCheckerMock) {
 				t.Helper()
@@ -314,7 +319,7 @@ func TestExpectationsAssertParameters(t *testing.T) {
 		{
 			uc:     "expected created parameter is missing",
 			params: httpsfv.InnerList{Params: httpsfv.NewParams()},
-			exp:    expectations{reqCreatedTS: &trueVal, reqExpiresTS: &falseVal},
+			exp:    expectations{reqCreatedTS: &trueVal, reqExpiresTS: &falseVal, reqNonceCheck: &falseVal},
 			configure: func(t *testing.T, nc *NonceCheckerMock) {
 				t.Helper()
 			},
@@ -329,7 +334,7 @@ func TestExpectationsAssertParameters(t *testing.T) {
 		{
 			uc:     "expected expires parameter is missing",
 			params: httpsfv.InnerList{Params: httpsfv.NewParams()},
-			exp:    expectations{reqCreatedTS: &falseVal, reqExpiresTS: &trueVal},
+			exp:    expectations{reqCreatedTS: &falseVal, reqExpiresTS: &trueVal, reqNonceCheck: &falseVal},
 			configure: func(t *testing.T, nc *NonceCheckerMock) {
 				t.Helper()
 			},
@@ -1093,8 +1098,12 @@ func TestVerifierVerify(t *testing.T) {
 			},
 		},
 		{
-			uc:   "signature parameters assertion error",
-			opts: []VerifierOption{WithRequiredTag("foo"), WithValidityTolerance(1 * time.Second)},
+			uc: "signature parameters assertion error",
+			opts: []VerifierOption{
+				WithRequiredTag("foo"),
+				WithValidityTolerance(1 * time.Second),
+				WithRequiredNonceCheck(false),
+			},
 			msg: &Message{
 				Header: http.Header{
 					"Signature-Input": []string{`sig=();expires=1618884470;keyid="test";tag="foo"`},
@@ -1120,6 +1129,7 @@ func TestVerifierVerify(t *testing.T) {
 				WithRequiredTag("foo"),
 				WithExpiredTimestampRequired(false),
 				WithCreatedTimestampRequired(false),
+				WithRequiredNonceCheck(false),
 			},
 			msg: &Message{
 				Header: http.Header{
@@ -1146,6 +1156,7 @@ func TestVerifierVerify(t *testing.T) {
 				WithRequiredTag("foo"),
 				WithExpiredTimestampRequired(false),
 				WithCreatedTimestampRequired(false),
+				WithRequiredNonceCheck(false),
 			},
 			msg: &Message{
 				Header: http.Header{
@@ -1271,11 +1282,45 @@ func TestVerifierVerify(t *testing.T) {
 			},
 		},
 		{
+			uc: "signature parameters negotiation fails because missing nonce parameter",
+			opts: []VerifierOption{
+				WithValidateAllSignatures(),
+				WithRequiredComponents("@method"),
+			},
+			msg: &Message{
+				Method:    http.MethodPost,
+				Authority: "example.com",
+				URL:       testURL,
+				Header: http.Header{
+					"Host":            []string{"example.com"},
+					"Content-Length":  []string{"18"},
+					"Signature-Input": []string{`sig=();created=1618884473;keyid="test-key";tag="foo"`},
+					"Signature":       []string{"sig=:dGVzdA==:"},
+				},
+				IsRequest: true,
+			},
+			configureResolver: func(t *testing.T, kr *KeyResolverMock) {
+				t.Helper()
+
+				kr.EXPECT().ResolveKey(mock.Anything, "test-key").Return(
+					Key{Key: tkRSAPSS, KeyID: "test-key", Algorithm: RsaPssSha512}, nil)
+			},
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+
+				require.Error(t, err)
+				require.ErrorIs(t, err, ErrParameter)
+				require.NotErrorIs(t, err, &NoApplicableSignatureError{})
+				require.ErrorContains(t, err, "expected nonce parameter not present")
+			},
+		},
+		{
 			uc: "signature verification fails due to invalid second content digest",
 			opts: []VerifierOption{
 				WithValidateAllSignatures(),
 				WithCreatedTimestampRequired(false),
 				WithExpiredTimestampRequired(false),
+				WithRequiredNonceCheck(false),
 			},
 			msg: &Message{
 				Method:    http.MethodPost,
@@ -1351,6 +1396,7 @@ func TestVerifierVerify(t *testing.T) {
 				WithValidateAllSignatures(),
 				WithCreatedTimestampRequired(false),
 				WithExpiredTimestampRequired(false),
+				WithRequiredNonceCheck(false),
 			},
 			msg: &Message{
 				Method:    http.MethodPost,
@@ -1389,6 +1435,7 @@ func TestVerifierVerify(t *testing.T) {
 				WithValidateAllSignatures(),
 				WithCreatedTimestampRequired(false),
 				WithExpiredTimestampRequired(false),
+				WithRequiredNonceCheck(false),
 			},
 			msg: &Message{
 				Method:    http.MethodPost,
@@ -1427,6 +1474,7 @@ func TestVerifierVerify(t *testing.T) {
 				WithValidateAllSignatures(),
 				WithCreatedTimestampRequired(false),
 				WithExpiredTimestampRequired(false),
+				WithRequiredNonceCheck(false),
 			},
 			msg: &Message{
 				Method:     http.MethodPost,
@@ -1463,6 +1511,7 @@ func TestVerifierVerify(t *testing.T) {
 				WithValidateAllSignatures(),
 				WithCreatedTimestampRequired(false),
 				WithExpiredTimestampRequired(false),
+				WithRequiredNonceCheck(false),
 			},
 			msg: &Message{
 				Method:    http.MethodPost,
@@ -1498,6 +1547,7 @@ func TestVerifierVerify(t *testing.T) {
 				WithValidateAllSignatures(),
 				WithCreatedTimestampRequired(false),
 				WithExpiredTimestampRequired(false),
+				WithRequiredNonceCheck(false),
 			},
 			msg: &Message{
 				Method:    http.MethodPost,

--- a/verifier_test.go
+++ b/verifier_test.go
@@ -940,6 +940,9 @@ func TestVerifierVerify(t *testing.T) {
 	tkEd25519, ok := key.(ed25519.PublicKey)
 	require.True(t, ok)
 
+	nc := NewNonceCheckerMock(t)
+	nc.EXPECT().CheckNonce(mock.Anything, "").Return(fmt.Errorf("empty nonce has been seen"))
+
 	for _, tc := range []struct {
 		uc                string
 		opts              []VerifierOption
@@ -1282,7 +1285,7 @@ func TestVerifierVerify(t *testing.T) {
 			},
 		},
 		{
-			uc: "signature parameters negotiation fails because missing nonce parameter",
+			uc: "signature parameters negotiation fails because missing nonce parameter and default has nonce check required",
 			opts: []VerifierOption{
 				WithValidateAllSignatures(),
 				WithRequiredComponents("@method"),
@@ -1312,6 +1315,41 @@ func TestVerifierVerify(t *testing.T) {
 				require.ErrorIs(t, err, ErrParameter)
 				require.NotErrorIs(t, err, &NoApplicableSignatureError{})
 				require.ErrorContains(t, err, "expected nonce parameter not present")
+			},
+		},
+		{
+			uc: "signature parameters negotiation fails because nonce parameter is invalid to the checker",
+			opts: []VerifierOption{
+				WithValidateAllSignatures(),
+				WithRequiredComponents("@method"),
+				WithRequiredNonceCheck(false),
+				WithNonceChecker(nc),
+			},
+			msg: &Message{
+				Method:    http.MethodPost,
+				Authority: "example.com",
+				URL:       testURL,
+				Header: http.Header{
+					"Host":            []string{"example.com"},
+					"Content-Length":  []string{"18"},
+					"Signature-Input": []string{`sig=();created=1618884473;keyid="test-key";nonce="";tag="foo"`},
+					"Signature":       []string{"sig=:dGVzdA==:"},
+				},
+				IsRequest: true,
+			},
+			configureResolver: func(t *testing.T, kr *KeyResolverMock) {
+				t.Helper()
+
+				kr.EXPECT().ResolveKey(mock.Anything, "test-key").Return(
+					Key{Key: tkRSAPSS, KeyID: "test-key", Algorithm: RsaPssSha512}, nil)
+			},
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+
+				require.Error(t, err)
+				require.ErrorIs(t, err, ErrVerificationFailed)
+				require.NotErrorIs(t, err, &NoApplicableSignatureError{})
+				require.ErrorContains(t, err, "nonce has been seen")
 			},
 		},
 		{

--- a/verifier_test.go
+++ b/verifier_test.go
@@ -120,8 +120,6 @@ func TestExpectationsAssertParameters(t *testing.T) {
 			expAlg: EcdsaP256Sha256,
 			configure: func(t *testing.T, nc *NonceCheckerMock) {
 				t.Helper()
-
-				nc.EXPECT().CheckNonce(mock.Anything, "").Return(nil)
 			},
 			assert: func(t *testing.T, err error) {
 				t.Helper()
@@ -144,8 +142,6 @@ func TestExpectationsAssertParameters(t *testing.T) {
 			exp: expectations{reqExpiresTS: &falseVal, reqCreatedTS: &falseVal},
 			configure: func(t *testing.T, nc *NonceCheckerMock) {
 				t.Helper()
-
-				nc.EXPECT().CheckNonce(mock.Anything, "").Return(nil)
 			},
 			assert: func(t *testing.T, err error) {
 				t.Helper()
@@ -172,8 +168,6 @@ func TestExpectationsAssertParameters(t *testing.T) {
 			},
 			configure: func(t *testing.T, nc *NonceCheckerMock) {
 				t.Helper()
-
-				nc.EXPECT().CheckNonce(mock.Anything, "").Return(nil)
 			},
 			assert: func(t *testing.T, err error) {
 				t.Helper()
@@ -198,8 +192,6 @@ func TestExpectationsAssertParameters(t *testing.T) {
 			},
 			configure: func(t *testing.T, nc *NonceCheckerMock) {
 				t.Helper()
-
-				nc.EXPECT().CheckNonce(mock.Anything, "").Return(nil)
 			},
 			assert: func(t *testing.T, err error) {
 				t.Helper()
@@ -220,8 +212,6 @@ func TestExpectationsAssertParameters(t *testing.T) {
 			exp: expectations{reqCreatedTS: &falseVal, reqExpiresTS: &falseVal},
 			configure: func(t *testing.T, nc *NonceCheckerMock) {
 				t.Helper()
-
-				nc.EXPECT().CheckNonce(mock.Anything, "").Return(nil)
 			},
 			assert: func(t *testing.T, err error) {
 				t.Helper()
@@ -248,8 +238,6 @@ func TestExpectationsAssertParameters(t *testing.T) {
 			},
 			configure: func(t *testing.T, nc *NonceCheckerMock) {
 				t.Helper()
-
-				nc.EXPECT().CheckNonce(mock.Anything, "").Return(nil)
 			},
 			assert: func(t *testing.T, err error) {
 				t.Helper()
@@ -274,8 +262,6 @@ func TestExpectationsAssertParameters(t *testing.T) {
 			},
 			configure: func(t *testing.T, nc *NonceCheckerMock) {
 				t.Helper()
-
-				nc.EXPECT().CheckNonce(mock.Anything, "").Return(nil)
 			},
 			assert: func(t *testing.T, err error) {
 				t.Helper()
@@ -296,8 +282,6 @@ func TestExpectationsAssertParameters(t *testing.T) {
 			exp: expectations{reqCreatedTS: &falseVal, reqExpiresTS: &falseVal},
 			configure: func(t *testing.T, nc *NonceCheckerMock) {
 				t.Helper()
-
-				nc.EXPECT().CheckNonce(mock.Anything, "").Return(nil)
 			},
 			assert: func(t *testing.T, err error) {
 				t.Helper()
@@ -318,8 +302,6 @@ func TestExpectationsAssertParameters(t *testing.T) {
 			}(),
 			configure: func(t *testing.T, nc *NonceCheckerMock) {
 				t.Helper()
-
-				nc.EXPECT().CheckNonce(mock.Anything, "").Return(nil)
 			},
 			assert: func(t *testing.T, err error) {
 				t.Helper()
@@ -335,8 +317,6 @@ func TestExpectationsAssertParameters(t *testing.T) {
 			exp:    expectations{reqCreatedTS: &trueVal, reqExpiresTS: &falseVal},
 			configure: func(t *testing.T, nc *NonceCheckerMock) {
 				t.Helper()
-
-				nc.EXPECT().CheckNonce(mock.Anything, "").Return(nil)
 			},
 			assert: func(t *testing.T, err error) {
 				t.Helper()
@@ -352,8 +332,6 @@ func TestExpectationsAssertParameters(t *testing.T) {
 			exp:    expectations{reqCreatedTS: &falseVal, reqExpiresTS: &trueVal},
 			configure: func(t *testing.T, nc *NonceCheckerMock) {
 				t.Helper()
-
-				nc.EXPECT().CheckNonce(mock.Anything, "").Return(nil)
 			},
 			assert: func(t *testing.T, err error) {
 				t.Helper()


### PR DESCRIPTION
Fix for #105 

We now skip nonce check if it's missing from the request parameters.