### PR TITLE
fix: Recompute `Content-Digest` header value when signing `content-digest` component

### DIFF
--- a/message_digester.go
+++ b/message_digester.go
@@ -20,11 +20,6 @@ type contentDigester struct {
 }
 
 func (c contentDigester) update(msg *Message) error {
-	if val := msg.Header.Get(headerContentDigest); len(val) != 0 {
-		// header already present. skipping
-		return nil
-	}
-
 	body, err := c.readBody(msg.Body)
 	if err != nil {
 		return err

--- a/message_digester_test.go
+++ b/message_digester_test.go
@@ -258,6 +258,62 @@ func TestContentDigesterUpdate(t *testing.T) {
 				})
 			},
 		},
+		{
+			uc:  "replaces existing content-digest values",
+			alg: Sha256,
+			msg: func() *Message {
+				req, err := http.NewRequestWithContext(
+					context.TODO(),
+					http.MethodPost,
+					"http://example.com/foo",
+					strings.NewReader(`{"hello": "world"}`),
+				)
+				require.NoError(t, err)
+
+				req.Header.Add("Content-Digest", "sha-256=:stale-sha256:")
+				req.Header.Add("Content-Digest", "sha-512=:stale-sha512:")
+
+				return MessageFromRequest(req)
+			}(),
+			assert: func(t *testing.T, err error, msg *Message) {
+				t.Helper()
+
+				require.NoError(t, err)
+
+				require.Equal(t, []string{
+					"sha-256=:X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=:",
+				}, msg.Header.Values("Content-Digest"))
+			},
+		},
+		{
+			uc: "replaces existing content-digest values without specified algorithm",
+			msg: func() *Message {
+				req, err := http.NewRequestWithContext(
+					context.TODO(),
+					http.MethodPost,
+					"http://example.com/foo",
+					strings.NewReader(`{"hello": "world"}`),
+				)
+				require.NoError(t, err)
+
+				req.Header.Set("Content-Digest", "sha-256=:stale:")
+
+				return MessageFromRequest(req)
+			}(),
+			assert: func(t *testing.T, err error, msg *Message) {
+				t.Helper()
+
+				require.NoError(t, err)
+
+				values := strings.Split(msg.Header.Get("Content-Digest"), ", ")
+				assert.ElementsMatch(t, values, []string{
+					"sha-256=:X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=:",
+					"sha-512=:WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX+TaPm+AbwAgBWnrIiYllu7BNNyealdVLvRwEmTHWXvJwew==:",
+				})
+
+				assert.NotContains(t, msg.Header.Get("Content-Digest"), "stale")
+			},
+		},
 	} {
 		t.Run(tc.uc, func(t *testing.T) {
 			cd := &contentDigester{alg: supportedAlgs[tc.alg], algName: tc.alg}

--- a/signer_test.go
+++ b/signer_test.go
@@ -638,6 +638,90 @@ func TestSignerSign(t *testing.T) {
 				assert.Equal(t, "sig-b26=:wqcAqbmYJ2ji2glfAMaRy4gruYYnx2nEFN2HN6jrnDnQCK1u02Gb04v9EDgwUPiu4A0w6vuQv5lIp5WPpBKRCw==:", sig)
 			},
 		},
+		{
+			uc:  "overwrites stale content-digest when signing content-digest component",
+			key: Key{KeyID: "test-key-rsa-pss", Algorithm: RsaPssSha512, Key: tkRSAPSS},
+			opts: []SignerOption{
+				WithNonce(NonceGetterFunc(func(_ context.Context) (string, error) { return "", nil })),
+				WithLabel("sig-content-digest"),
+				WithTTL(0),
+				WithComponents("content-digest"),
+				WithContentDigestAlgorithm(Sha256),
+			},
+			msg: &Message{
+				Method:    http.MethodPost,
+				Authority: "example.com",
+				URL:       testURL,
+				Header: http.Header{
+					"Host":           []string{"example.com"},
+					"Date":           []string{"Tue, 20 Apr 2021 02:07:55 GMT"},
+					"Content-Type":   []string{"application/json"},
+					"Content-Digest": []string{"sha-256=:stale:"},
+					"Content-Length": []string{"18"},
+				},
+				IsRequest: true,
+				Body: func() (io.ReadCloser, error) {
+					return io.NopCloser(strings.NewReader(`{"hello": "world"}`)), nil
+				},
+			},
+			assert: func(t *testing.T, err error, header http.Header) {
+				t.Helper()
+
+				require.NoError(t, err)
+
+				assert.Equal(
+					t,
+					"sha-256=:X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=:",
+					header.Get("Content-Digest"),
+				)
+
+				sigInput := header.Get("Signature-Input")
+				assert.Equal(t, `sig-content-digest=("content-digest");created=1618884473;keyid="test-key-rsa-pss"`, sigInput)
+
+				sig := header.Get("Signature")
+				assert.True(t, strings.HasPrefix(sig, "sig-content-digest=:"))
+			},
+		},
+		{
+			uc:  "preserves existing content-digest when content-digest component is not signed",
+			key: Key{KeyID: "test-key-rsa-pss", Algorithm: RsaPssSha512, Key: tkRSAPSS},
+			opts: []SignerOption{
+				WithNonce(NonceGetterFunc(func(_ context.Context) (string, error) { return "", nil })),
+				WithLabel("sig-no-content-digest"),
+				WithTTL(0),
+				WithComponents("date", "@method"),
+				WithContentDigestAlgorithm(Sha256),
+			},
+			msg: &Message{
+				Method:    http.MethodPost,
+				Authority: "example.com",
+				URL:       testURL,
+				Header: http.Header{
+					"Host":           []string{"example.com"},
+					"Date":           []string{"Tue, 20 Apr 2021 02:07:55 GMT"},
+					"Content-Type":   []string{"application/json"},
+					"Content-Digest": []string{"sha-256=:stale:"},
+					"Content-Length": []string{"18"},
+				},
+				IsRequest: true,
+				Body: func() (io.ReadCloser, error) {
+					return io.NopCloser(strings.NewReader(`{"hello": "world"}`)), nil
+				},
+			},
+			assert: func(t *testing.T, err error, header http.Header) {
+				t.Helper()
+
+				require.NoError(t, err)
+
+				assert.Equal(t, "sha-256=:stale:", header.Get("Content-Digest"))
+
+				sigInput := header.Get("Signature-Input")
+				assert.Equal(t, `sig-no-content-digest=("date" "@method");created=1618884473;keyid="test-key-rsa-pss"`, sigInput)
+
+				sig := header.Get("Signature")
+				assert.True(t, strings.HasPrefix(sig, "sig-no-content-digest=:"))
+			},
+		},
 	} {
 		t.Run(tc.uc, func(t *testing.T) {
 			s, err := NewSigner(tc.key, tc.opts...)

--- a/signer_test.go
+++ b/signer_test.go
@@ -457,6 +457,7 @@ func TestSignerSign(t *testing.T) {
 				WithTTL(0),
 				WithComponents("@authority", "content-digest", "@query-param;name=\"Pet\""),
 				WithTag("header-example"),
+				WithContentDigestAlgorithm(Sha512),
 			},
 			msg: &Message{
 				Method:    http.MethodPost,
@@ -498,6 +499,7 @@ func TestSignerSign(t *testing.T) {
 				WithComponents(
 					"date", "@method", "@path", "@query", "@authority", "content-type", "content-digest", "content-length",
 				),
+				WithContentDigestAlgorithm(Sha512),
 			},
 			msg: &Message{
 				Method:    http.MethodPost,
@@ -537,6 +539,7 @@ func TestSignerSign(t *testing.T) {
 				WithLabel("sig-b24"),
 				WithTTL(0),
 				WithComponents("@status", "content-type", "content-digest", "content-length"),
+				WithContentDigestAlgorithm(Sha512),
 			},
 			msg: &Message{
 				Method:    http.MethodPost,


### PR DESCRIPTION
This PR changes the signing behavior for the `content-digest` component.

When `content-digest` is configured as one of the signature components, the signer now always recomputes the `Content-Digest` header from the current message body and replaces any existing value.

Previously, an existing `Content-Digest` header was preserved. If that header was stale or incorrect, signing could produce a message that fails verification because the signed digest no longer matches the body.
